### PR TITLE
replace Async write ha state with schedule_update_ha_state

### DIFF
--- a/custom_components/cync_lights/binary_sensor.py
+++ b/custom_components/cync_lights/binary_sensor.py
@@ -38,7 +38,7 @@ class CyncMotionSensorEntity(BinarySensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
-        self.motion_sensor.register(self.async_write_ha_state)
+        self.motion_sensor.register(self.schedule_update_ha_state)
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""
@@ -85,7 +85,7 @@ class CyncAmbientLightSensorEntity(BinarySensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
-        self.ambient_light_sensor.register(self.async_write_ha_state)
+        self.ambient_light_sensor.register(self.schedule_update_ha_state)
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""

--- a/custom_components/cync_lights/fan.py
+++ b/custom_components/cync_lights/fan.py
@@ -37,7 +37,7 @@ class CyncFanEntity(FanEntity):
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
-        self.cync_switch.register(self.async_write_ha_state)
+        self.cync_switch.register(self.schedule_update_ha_state)
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""

--- a/custom_components/cync_lights/light.py
+++ b/custom_components/cync_lights/light.py
@@ -42,7 +42,7 @@ class CyncRoomEntity(LightEntity):
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
-        self.room.register(self.async_write_ha_state)
+        self.room.register(self.schedule_update_ha_state)
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""
@@ -157,7 +157,7 @@ class CyncSwitchEntity(LightEntity):
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
-        self.cync_switch.register(self.async_write_ha_state)
+        self.cync_switch.register(self.schedule_update_ha_state)
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""

--- a/custom_components/cync_lights/switch.py
+++ b/custom_components/cync_lights/switch.py
@@ -37,7 +37,7 @@ class CyncPlugEntity(SwitchEntity):
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
-        self.cync_switch.register(self.async_write_ha_state)
+        self.cync_switch.register(self.schedule_update_ha_state)
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance state update scheduling by replacing async_write_ha_state with schedule_update_ha_state in multiple components including binary_sensor, light, fan, and switch.

Enhancements:
- Replace async_write_ha_state with schedule_update_ha_state for better scheduling of state updates in various components.

<!-- Generated by sourcery-ai[bot]: end summary -->